### PR TITLE
Fixed error when calling compute_correspondences

### DIFF
--- a/src/NeighbourFinder.hpp
+++ b/src/NeighbourFinder.hpp
@@ -99,8 +99,8 @@ void NeighbourFinder<VecMatType>::set_source_points(const VecMatType * const inS
     //# Update internal data structures
     //## The kd-tree has to be rebuilt.
     if (_kdTree != NULL) { delete _kdTree; _kdTree = NULL;}
-    _kdTree = new nanoflann::KDTreeEigenMatrixAdaptor<VecMatType>(*_inSourcePoints,
-                                                                _leafSize);
+    _kdTree = new nanoflann::KDTreeEigenMatrixAdaptor<VecMatType>(_numDimensions
+                                                                  *_inSourcePoints);
     _kdTree->index->buildIndex();
 }
 


### PR DESCRIPTION
This has 2 issues.
1. Compile time error when make a build using CMAKE on my Mac (Other OS should be the same) folling this line.
`_kdTree = new nanoflann::KDTreeEigenMatrixAdaptor<VecMatType(_inSourcePoints, _leafSize);`
2. I fixed using this line
`_kdTree = new nanoflann::KDTreeEigenMatrixAdaptor<VecMatType>(_numDimensions, *_inSourcePoints);`

By the way, I have removed _leafSize, which is an optional parameter, as it's kind of optimization purpose. I can make a new commit or make some tests if you prefer.

PS. I am currently considering to include MashMonk with my master thesis. I might do more tests or adjust some parameters. So, you can tell me if you need some more tests. 

Thank you,
