### PR TITLE
Invalid field TextureCoordinate in OBJ field (upSampleMesh.m)

### DIFF
--- a/matlab/object_classes/3D Objects v2017/@shape3D/upSampleMesh.m
+++ b/matlab/object_classes/3D Objects v2017/@shape3D/upSampleMesh.m
@@ -81,7 +81,7 @@ function Findex = performSubdivision(obj,Findex)
     if ~isempty(obj.VertexRGB)
        rgb = obj.VertexRGB';
        rgb = [rgb, (rgb(:,i)+rgb(:,j))/2 ];
-       obj.TextureColor = rgb';
+       obj.VertexRGB = rgb';
        clear rgb;
     end
     if ~isempty(obj.UV)


### PR DESCRIPTION
When using a textured obj wavefront file within meshmonk, an error about the obj class not having the TextureCoordinate field. 
Changed the allocation from this field to the vertexRGB variant. 

Matlab version 2020b