### PR TITLE
Adapt MATLAB MEX build for CMake-built libmeshmonk_shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,5 +172,81 @@ If you want to use MeshMonk's functionalities in your own C++ projects:
     *   [OSX (Legacy)](docs/osx.md)
     *   [Windows (Legacy)](docs/windows.md)
 
+## Using MeshMonk from MATLAB
+
+To use MeshMonk's functionalities within MATLAB, you first need to build the core shared library using CMake and then compile the MEX functions.
+
+### 1. Build `libmeshmonk_shared` via CMake
+
+Follow the main build instructions in this README to configure and build MeshMonk using CMake. This will produce the `libmeshmonk_shared` library (e.g., `libmeshmonk_shared.so` on Linux, `libmeshmonk_shared.dylib` on macOS, or `meshmonk_shared.dll` and `meshmonk_shared.lib` on Windows). This library is typically found in the `build/library/` directory (or `build/bin/` for the DLL on Windows, depending on CMake configuration).
+
+### 2. Compile MEX Functions
+
+Once `libmeshmonk_shared` is built, you can compile the MEX functions:
+
+1.  Open MATLAB.
+2.  Navigate MATLAB's current directory to the `matlab/` directory within the MeshMonk project (e.g., `cd path/to/meshmonk/matlab`).
+3.  Run the appropriate MEX compilation script:
+    *   On **Linux or macOS**: Execute `mex_all` in the MATLAB command window.
+    *   On **Windows**: Execute `mex_windows_all` in the MATLAB command window.
+
+    ```matlab
+    % For Linux/macOS
+    mex_all
+    
+    % For Windows
+    % mex_windows_all
+    ```
+
+    These scripts will compile all necessary MEX functions and place them in the current directory (`matlab/`).
+
+**Notes for MEX Compilation:**
+*   The MEX scripts (`mex_all.m` and `mex_windows_all.m`) assume that the MeshMonk project root is one level above the `matlab/` directory (i.e., `meshmonkRoot = '..';`).
+*   The scripts expect to find Eigen3 headers in a directory fetched by CMake (typically `build/_deps/eigen-src/`). If you have Eigen3 installed in a custom system location, you may need to modify the `eigenIncludeDir` variable at the beginning of the respective `mex_*.m` script.
+*   Similarly, OpenMesh headers are expected to be found within the CMake build directory (`build/vendor/OpenMesh-11.0.0/_build/src/`).
+
+### 3. MATLAB Runtime Environment Setup
+
+For MATLAB to find `libmeshmonk_shared` and the compiled MEX functions at runtime:
+
+*   **MEX Functions:** The demo scripts in the `demo/` directory are configured to find MEX files if they are located in the `matlab/` directory (due to `addpath(fullfile('..', 'matlab'))`). Ensure your compiled MEX files (`.mexa64`, `.mexw64`, etc.) are in `matlab/`.
+
+*   **`libmeshmonk_shared` Library:**
+    *   **Linux:** Add the directory containing `libmeshmonk_shared.so` (e.g., `path/to/meshmonk/build/library/`) to your `LD_LIBRARY_PATH` environment variable before launching MATLAB.
+      ```bash
+      export LD_LIBRARY_PATH=/path/to/meshmonk/build/library:$LD_LIBRARY_PATH
+      matlab
+      ```
+      For a persistent setting, add this line to your `~/.bashrc` or `~/.zshrc`.
+
+    *   **macOS:** Add the directory containing `libmeshmonk_shared.dylib` (e.g., `path/to/meshmonk/build/library/`) to your `DYLD_LIBRARY_PATH` environment variable.
+      ```bash
+      export DYLD_LIBRARY_PATH=/path/to/meshmonk/build/library:$DYLD_LIBRARY_PATH
+      matlab
+      ```
+      Alternatively, you can create a `startup.m` file in your MATLAB user path (typically `~/Documents/MATLAB/`) and add:
+      ```matlab
+      addpath('path/to/meshmonk/build/library'); 
+      % Or, more robustly for .dylib, consider a symbolic link or install_name_tool adjustments post-build.
+      % However, DYLD_LIBRARY_PATH is the most common method for .dylib files not in standard locations.
+      ```
+      *(Note: `addpath` in `startup.m` is generally for M-files and MEX-files, not typically for `.dylib` dependencies directly, but MATLAB might pick them up if they are in its search path. `DYLD_LIBRARY_PATH` is more reliable for shared libraries.)*
+
+    *   **Windows:** Ensure the directory containing `meshmonk_shared.dll` (e.g., `path/to/meshmonk/build/library/` or `path/to/meshmonk/build/bin/`) is in your system's `PATH` environment variable. Alternatively, you can add this directory to MATLAB's path using a `startup.m` file in your MATLAB user path (typically `Documents\MATLAB\`):
+      ```matlab
+      addpath('C:\path\to\meshmonk\build\library'); % Or wherever the .dll is
+      ```
+
+### 4. Running Demo Scripts
+
+The demo scripts (e.g., `test_compute_correspondences.m`) are located in the `demo/` directory.
+1.  Open MATLAB.
+2.  Ensure your runtime environment is set up as described above.
+3.  Navigate MATLAB's current directory to `path/to/meshmonk/demo/`.
+4.  Open and run any of the `test_*.m` scripts. For example:
+    ```matlab
+    test_compute_correspondences
+    ```
+
 ---
 *MATLAB and Python support are planned for future development phases.*

--- a/demo/test_compute_correspondences.m
+++ b/demo/test_compute_correspondences.m
@@ -1,14 +1,11 @@
 %% Demo compute correspondences
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load template shape (floating) and target'
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFeatures = [floatingPoints, 1/sqrt(3.0)*ones(size(floatingPoints))];
 floatingFeatures = single(floatingFeatures);
@@ -17,7 +14,7 @@ numFloatingElements = size(floatingFeatures,1);
 floatingFlags = single(ones(numFloatingElements,1));
 clear floatingPoints;
 
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetFeatures = single([targetPoints, 1/sqrt(3.0)*ones(size(targetPoints))]);
 targetFaces = uint32(targetFaces-1);        %-1 to make it compatible with C++ indexing 

--- a/demo/test_downsample_mesh.m
+++ b/demo/test_downsample_mesh.m
@@ -1,15 +1,12 @@
 %% Demo downsample mesh
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load Data
 
 %Load a mesh
-floatingPath = [studypath '/demoFace.obj'];
+floatingPath = 'demoFace.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);

--- a/demo/test_nonrigid_registration.m
+++ b/demo/test_nonrigid_registration.m
@@ -1,14 +1,11 @@
 %% Demo nonrigid registration modular
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -19,7 +16,7 @@ numFloatingElements = size(floatingFeatures,1);
 floatingFlags = single(ones(numFloatingElements,1));
 clear floatingPoints;
  
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/demo/test_nonrigid_registration_modular.m
+++ b/demo/test_nonrigid_registration_modular.m
@@ -1,14 +1,11 @@
 %% Demo nonrigid registration modular
  
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -22,7 +19,7 @@ floatingFlags(1:1000) = 0.0;
 clear floatingPoints;
 
 %Load a mesh
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/demo/test_pyramid_registration.m
+++ b/demo/test_pyramid_registration.m
@@ -1,14 +1,11 @@
 %% Demo pyramid registration 
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -19,7 +16,7 @@ numFloatingElements = size(floatingFeatures,1);
 floatingFlags = single(ones(numFloatingElements,1));
 clear floatingPoints;
 
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/demo/test_pyramid_registration_modular.m
+++ b/demo/test_pyramid_registration_modular.m
@@ -1,14 +1,11 @@
 %% Demo pyramid registration modular
 
-% % Add MeshMonk's toolbox to the working path and setup current folder
-% addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-% 
-% studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-% cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -19,7 +16,7 @@ numFloatingElements = size(floatingFeatures,1);
 floatingFlags = single(ones(numFloatingElements,1));
 clear floatingPoints;
 
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/demo/test_rigid_registration.m
+++ b/demo/test_rigid_registration.m
@@ -1,14 +1,11 @@
 %% Demo rigid registration 
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -22,7 +19,7 @@ floatingFlags(1:1000) = 0.0;
 %END DEBUG
 clear floatingPoints;
 
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/demo/test_rigid_registration_modular.m
+++ b/demo/test_rigid_registration_modular.m
@@ -1,14 +1,11 @@
 %% Demo rigid registration modular
 
-% Add MeshMonk's toolbox to the working path and setup current folder
-addpath(genpath('path\to\meshmonk')) % Set to location of meshmonk
-
-studypath = 'path\to\DemoFolder\';   % Set to location of demo material
-cd(studypath);
+% Add path to compiled MEX files (assuming mex_all.m was run in matlab/ directory)
+addpath(fullfile('..', 'matlab'));
 
 %% Load face template (floating) and face (target)
 
-floatingPath = [studypath '/Template.obj'];
+floatingPath = 'Template.obj';
 [floatingPoints,floatingFaces] = read_vertices_and_faces_from_obj_file(floatingPath);
 floatingFaces = uint32(floatingFaces-1); %-1 to make it compatible with C++ indexing
 floatingPoints = single(floatingPoints);
@@ -22,7 +19,7 @@ floatingFlags(1:1000) = 0.0;
 %END DEBUG
 clear floatingPoints;
 
-targetPath = [studypath '/demoFace.obj'];
+targetPath = 'demoFace.obj';
 [targetPoints,targetFaces] = read_vertices_and_faces_from_obj_file(targetPath);
 targetPoints = single(targetPoints);
 targetFaces = uint32(targetFaces-1);%-1 to make it compatible with C++ indexing

--- a/matlab/mex_all.m
+++ b/matlab/mex_all.m
@@ -1,18 +1,15 @@
 % Define base paths
-% It's generally better practice for the user to set meshmonkRoot appropriately
-% or for the script to determine it dynamically, but for this automated step,
-% we'll use the fixed absolute path based on the execution environment.
-meshmonkRoot = '/app'; 
+meshmonkRoot = '..'; 
 
 % Include directories
-eigenIncludeDir = '/usr/include/eigen3'; % Standard system path for Eigen
-openMeshIncludeDir = fullfile(meshmonkRoot, 'vendor', 'OpenMesh-11.0.0', 'src');
-meshmonkIncludeDir = meshmonkRoot;
-meshmonkSrcDir = fullfile(meshmonkRoot, 'src');
+eigenIncludeDir = fullfile(meshmonkRoot, 'build', '_deps', 'eigen-src');
+openMeshIncludeDir = fullfile(meshmonkRoot, 'build', 'vendor', 'OpenMesh-11.0.0', '_build', 'src');
+meshmonkIncludeDir = fullfile(meshmonkRoot, 'library', 'include');
+meshmonkSrcDir = fullfile(meshmonkRoot, 'library', 'src');
 meshmonkVendorDir = fullfile(meshmonkRoot, 'vendor'); % For nanoflann.hpp
 
 % Library directory
-libDir = fullfile(meshmonkRoot, 'build');
+libDir = fullfile(meshmonkRoot, 'build', 'library');
 
 % Common MEX flags
 % Using C++17 standard, consistent with the main CMake build
@@ -21,10 +18,13 @@ libDir = fullfile(meshmonkRoot, 'build');
 % For now, assuming no explicit OpenMP flags needed directly in mex command here if not in main build.
 commonFlags = { ...
     ['-I', meshmonkIncludeDir], ...
-    ['-I', meshmonkSrcDir], ...
-    ['-I', meshmonkVendorDir], ...
+    ['-I', fullfile(meshmonkIncludeDir, 'meshmonk')], ... % to access headers like meshmonk/global.hpp
+    ['-I', meshmonkSrcDir], ... % if internal headers from library/src are directly included by MEX files
+    ['-I', meshmonkVendorDir], ... % for nanoflann.hpp
     ['-I', eigenIncludeDir], ...
     ['-I', openMeshIncludeDir], ...
+    ['-I', fullfile(openMeshIncludeDir, 'OpenMesh', 'Core')], ... % OpenMesh headers are often in subdirectories
+    ['-I', fullfile(openMeshIncludeDir, 'OpenMesh', 'Tools')], ...
     ['-L', libDir], ...
     '-lmeshmonk_shared', ...
     '-lstdc++' ... % Common on Linux, might need adjustment for other OS

--- a/matlab/mex_windows_all.m
+++ b/matlab/mex_windows_all.m
@@ -1,37 +1,115 @@
-%Defining compiler flags
-c_om = ['-I', '%ProgramFiles%\OpenMesh 6.3\include'];
-c_mesh = ['-I', '%USERPROFILE%\Documents\GitHub\meshmonk'];
-c_nano = ['-I', '%USERPROFILE%\Documents\GitHub\meshmonk\vendor'];
-c_eigen = ['-I', '%USERPROFILE%\Documents\GitHub\eigen-eigen-3.3.4'];
-c_math = ['-D', '_USE_MATH_DEFINES'];
-c_lib = ['-l', 'meshmonk'];
+% Define base paths
+meshmonkRoot = '..'; 
 
-disp('Mexing "compute_correspondences"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/compute_correspondences.cpp')
+% Include directories
+eigenIncludeDir = fullfile(meshmonkRoot, 'build', '_deps', 'eigen-src'); % Assumes Eigen is available via CMake's FetchContent. User might need to change this if their Eigen is elsewhere.
+openMeshIncludeDir = fullfile(meshmonkRoot, 'build', 'vendor', 'OpenMesh-11.0.0', '_build', 'src'); % This path is based on the CMake build structure.
+meshmonkIncludeDir = fullfile(meshmonkRoot, 'library', 'include');
+meshmonkSrcDir = fullfile(meshmonkRoot, 'library', 'src');
+meshmonkVendorDir = fullfile(meshmonkRoot, 'vendor'); % For nanoflann.hpp
 
-disp('Mexing "compute_inlier_weights"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/compute_inlier_weights.cpp')
+% Library directory
+libDir = fullfile(meshmonkRoot, 'build', 'library'); % Expects meshmonk_shared.lib here. The corresponding .dll should be in system's PATH or MATLAB's path at runtime.
 
-disp('Mexing "compute_nonrigid_transformation"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/compute_nonrigid_transformation.cpp')
+% Common MEX flags
+% For C++ standard, using COMPFLAGS. MSVC uses /std:c++17
+% Using CXXFLAGS here as a placeholder if COMPFLAGS doesn't work as expected directly in the list.
+% The typical way is: mex COMPFLAGS="\$COMPFLAGS /std:c++17" ...
+% For this script, we'll add it to the list of flags directly.
+commonFlags = { ...
+    ['-I', meshmonkIncludeDir], ...
+    ['-I', fullfile(meshmonkIncludeDir, 'meshmonk')], ... % to access headers like meshmonk/global.hpp
+    ['-I', meshmonkSrcDir], ... % if internal headers from library/src are directly included by MEX files
+    ['-I', meshmonkVendorDir], ... % for nanoflann.hpp
+    ['-I', eigenIncludeDir], ...
+    ['-I', openMeshIncludeDir], ...
+    ['-I', fullfile(openMeshIncludeDir, 'OpenMesh', 'Core')], ... % OpenMesh headers are often in subdirectories
+    ['-I', fullfile(openMeshIncludeDir, 'OpenMesh', 'Tools')], ...
+    ['-L', libDir], ...
+    '-lmeshmonk_shared', ... % mex handles .lib extension automatically
+    '-D_USE_MATH_DEFINES', ... % Common define for Windows
+    'COMPFLAGS="/std:c++17"' % For MSVC compiler, ensure C++17 standard
+};
 
-disp('Mexing "compute_rigid_transformation"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/compute_rigid_transformation.cpp')
+% Source files directory
+mexSrcDir = fullfile(meshmonkRoot, 'matlab', 'mex');
 
-disp('Mexing "downsample_mesh"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/downsample_mesh.cpp')
+% List of MEX files to compile (base names)
+mexFiles = {
+    'compute_correspondences', ...
+    'compute_inlier_weights', ...
+    'compute_nonrigid_transformation', ...
+    'compute_rigid_transformation', ...
+    'downsample_mesh', ...
+    'nonrigid_registration', ...
+    'pyramid_registration', ...
+    'rigid_registration', ...
+    'scaleshift_mesh', ...
+    'compute_normals' ...
+};
 
-disp('Mexing "nonrigid_registration"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/nonrigid_registration.cpp')
+disp('Starting MEX compilation for MeshMonk (Windows)...');
 
-disp('Mexing "pyramid_registration"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/pyramid_registration.cpp')
+for i = 1:length(mexFiles)
+    baseName = mexFiles{i};
+    cppFile = fullfile(mexSrcDir, [baseName, '.cpp']);
+    outputName = baseName; % Output name will be 'baseName.mexw64' or similar
 
-disp('Mexing "rigid_registration"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/rigid_registration.cpp')
+    disp(['Mexing "', baseName, '" from "', cppFile, '"...']);
+    
+    % Construct the mex command
+    % The flags in commonFlags are passed as separate arguments to mex.
+    % COMPFLAGS is a special argument to mex.
+    
+    % Separate COMPFLAGS from other flags for clarity in command construction
+    compileFlags = {};
+    linkFlags = {};
+    otherMexArgs = {};
+    compFlagsValue = '';
 
-disp('Mexing "scaleshift_mesh"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/scaleshift_mesh.cpp')
+    for k = 1:length(commonFlags)
+        flag = commonFlags{k};
+        if startsWith(flag, 'COMPFLAGS=')
+            compFlagsValue = flag; % Keep it as is, e.g., 'COMPFLAGS="/std:c++17"'
+        elseif startsWith(flag, '-L') || startsWith(flag, '-l')
+            linkFlags{end+1} = flag; %#ok<AGROW>
+        else
+            compileFlags{end+1} = flag; %#ok<AGROW>
+        end
+    end
+    
+    mexCommandParts = {'mex'};
+    if ~isempty(compFlagsValue)
+        mexCommandParts{end+1} = compFlagsValue;
+    end
+    mexCommandParts = [mexCommandParts, compileFlags, linkFlags, {cppFile}];
+    
+    % Create the command string for display and evaluation
+    mexCommand = strjoin(mexCommandParts, ' ');
+    
+    disp(['Executing: ', mexCommand]);
+    
+    try
+        % Use feval for safer execution of mex with dynamic arguments
+        argsToMex = [compileFlags, linkFlags, {cppFile}];
+        if ~isempty(compFlagsValue)
+             % Find the actual value for COMPFLAGS, e.g. "/std:c++17"
+            compVal = extractBetween(compFlagsValue, '"', '"');
+            if isempty(compVal) % Fallback if quotes were not used as expected
+                compVal = extractAfter(compFlagsValue, '=');
+            end
+            feval('mex', 'COMPFLAGS', compVal{1}, argsToMex{:});
+        else
+            feval('mex', argsToMex{:});
+        end
+        disp(['Successfully mexed "', outputName, '".']);
+    catch e
+        disp(['Error mexing "', outputName, '":']);
+        disp(e.message);
+        disp(e.getReport('extended', 'on', 'hyperlinks', 'off'));
+        disp('Skipping this file and continuing...');
+    end
+    disp('---');
+end
 
-disp('Mexing "compute_normals"...')
-mex(c_om, c_mesh, c_nano, c_eigen, c_math, c_lib, 'matlab/mex/compute_normals.cpp')
+disp('MEX compilation finished.');


### PR DESCRIPTION
This commit updates the MATLAB MEX build process to be compatible with the CMake-built `libmeshmonk_shared` library.

Key changes:
- Modified `matlab/mex_all.m` and `matlab/mex_windows_all.m`:
    - Updated include paths to point to public headers of `libmeshmonk_shared`, internal headers (if used), Eigen3 headers (via FetchContent or system), and OpenMesh headers from the CMake build directory.
    - Updated library paths to point to the directory containing the CMake-built `libmeshmonk_shared`.
    - Ensured MEX commands link against `meshmonk_shared` and necessary system libraries, removing explicit linkage to OpenMeshCore/Tools at the MEX stage.
    - Standardized script structure for path definitions and looped compilation.
- Updated MATLAB demo scripts (`demo/test_*.m`):
    - Modified to load mesh data from the common `demo/` directory using relative paths.
    - Adjusted `addpath` to locate compiled MEX files correctly.
- Verified paths in the modified MEX scripts and demo scripts through a "dry run" against an expected CMake build structure.
- Updated `README.md`:
    - Added a comprehensive section "Using MeshMonk from MATLAB" detailing the new build process: 1. Build `libmeshmonk_shared` via CMake. 2. Compile MEX functions using the updated scripts. 3. Set up the MATLAB runtime environment (LD_LIBRARY_PATH, DYLD_LIBRARY_PATH, or system PATH for Windows).